### PR TITLE
Add dilated RedNet support

### DIFF
--- a/det/mmdet/models/backbones/rednet.py
+++ b/det/mmdet/models/backbones/rednet.py
@@ -80,7 +80,7 @@ class Bottleneck(nn.Module):
             stride=self.conv1_stride,
             bias=False)
         self.add_module(self.norm1_name, norm1)
-        self.conv2 = involution(self.mid_channels, 7, self.conv2_stride)
+        self.conv2 = involution(self.mid_channels, 7, self.conv2_stride, dilation=dilation)
 
         self.add_module(self.norm2_name, norm2)
         self.conv3 = build_conv_layer(
@@ -201,6 +201,7 @@ class ResLayer(nn.Sequential):
                  out_channels,
                  expansion=None,
                  stride=1,
+                 dilation=1,
                  avg_down=False,
                  conv_cfg=None,
                  norm_cfg=dict(type='BN'),
@@ -239,6 +240,7 @@ class ResLayer(nn.Sequential):
                 out_channels=out_channels,
                 expansion=self.expansion,
                 stride=stride,
+                dilation=dilation,
                 downsample=downsample,
                 conv_cfg=conv_cfg,
                 norm_cfg=norm_cfg,
@@ -251,6 +253,7 @@ class ResLayer(nn.Sequential):
                     out_channels=out_channels,
                     expansion=self.expansion,
                     stride=1,
+                    dilation=dilation,
                     conv_cfg=conv_cfg,
                     norm_cfg=norm_cfg,
                     **kwargs))

--- a/det/mmdet/models/utils/involution_cuda.py
+++ b/det/mmdet/models/utils/involution_cuda.py
@@ -248,10 +248,12 @@ class involution(nn.Module):
     def __init__(self,
                  channels,
                  kernel_size,
-                 stride):
+                 stride,
+                 dilation=1):
         super(involution, self).__init__()
         self.kernel_size = kernel_size
         self.stride = stride
+        self.dilation = dilation
         self.channels = channels
         reduction_ratio = 4
         self.group_channels = 16
@@ -278,5 +280,5 @@ class involution(nn.Module):
         weight = self.conv2(self.conv1(x if self.stride == 1 else self.avgpool(x)))
         b, c, h, w = weight.shape
         weight = weight.view(b, self.groups, self.kernel_size, self.kernel_size, h, w)
-        out = _involution_cuda(x, weight, stride=self.stride, padding=(self.kernel_size-1)//2)
+        out = _involution_cuda(x, weight, stride=self.stride, padding=self.dilation * (self.kernel_size-1) // 2, dilation=self.dilation)
         return out

--- a/det/mmdet/models/utils/involution_naive.py
+++ b/det/mmdet/models/utils/involution_naive.py
@@ -7,10 +7,12 @@ class involution(nn.Module):
     def __init__(self,
                  channels,
                  kernel_size,
-                 stride):
+                 stride,
+                 dilation=1):
         super(involution, self).__init__()
         self.kernel_size = kernel_size
         self.stride = stride
+        self.dilation=dilation
         self.channels = channels
         reduction_ratio = 4
         self.group_channels = 16
@@ -32,7 +34,7 @@ class involution(nn.Module):
             act_cfg=None)
         if stride > 1:
             self.avgpool = nn.AvgPool2d(stride, stride)
-        self.unfold = nn.Unfold(kernel_size, 1, (kernel_size-1)//2, stride)
+        self.unfold = nn.Unfold(kernel_size, dilation, dilation * (kernel_size-1) // 2, stride)
 
     def forward(self, x):
         weight = self.conv2(self.conv1(x if self.stride == 1 else self.avgpool(x)))

--- a/seg/mmseg/models/backbones/rednet.py
+++ b/seg/mmseg/models/backbones/rednet.py
@@ -80,7 +80,7 @@ class Bottleneck(nn.Module):
             stride=self.conv1_stride,
             bias=False)
         self.add_module(self.norm1_name, norm1)
-        self.conv2 = involution(self.mid_channels, 7, self.conv2_stride)
+        self.conv2 = involution(self.mid_channels, 7, self.conv2_stride, dilation=dilation)
 
         self.add_module(self.norm2_name, norm2)
         self.conv3 = build_conv_layer(
@@ -201,6 +201,7 @@ class ResLayer(nn.Sequential):
                  out_channels,
                  expansion=None,
                  stride=1,
+                 dilation=1,
                  avg_down=False,
                  conv_cfg=None,
                  norm_cfg=dict(type='BN'),
@@ -239,6 +240,7 @@ class ResLayer(nn.Sequential):
                 out_channels=out_channels,
                 expansion=self.expansion,
                 stride=stride,
+                dilation=dilation,
                 downsample=downsample,
                 conv_cfg=conv_cfg,
                 norm_cfg=norm_cfg,
@@ -251,6 +253,7 @@ class ResLayer(nn.Sequential):
                     out_channels=out_channels,
                     expansion=self.expansion,
                     stride=1,
+                    dilation=dilation,
                     conv_cfg=conv_cfg,
                     norm_cfg=norm_cfg,
                     **kwargs))

--- a/seg/mmseg/models/utils/involution_cuda.py
+++ b/seg/mmseg/models/utils/involution_cuda.py
@@ -248,10 +248,12 @@ class involution(nn.Module):
     def __init__(self,
                  channels,
                  kernel_size,
-                 stride):
+                 stride,
+                 dilation=1):
         super(involution, self).__init__()
         self.kernel_size = kernel_size
         self.stride = stride
+        self.dilation = dilation
         self.channels = channels
         reduction_ratio = 4
         self.group_channels = 16
@@ -278,5 +280,5 @@ class involution(nn.Module):
         weight = self.conv2(self.conv1(x if self.stride == 1 else self.avgpool(x)))
         b, c, h, w = weight.shape
         weight = weight.view(b, self.groups, self.kernel_size, self.kernel_size, h, w)
-        out = _involution_cuda(x, weight, stride=self.stride, padding=(self.kernel_size-1)//2)
+        out = _involution_cuda(x, weight, stride=self.stride, padding=self.dilation * (self.kernel_size-1) // 2, dilation=self.dilation)
         return out

--- a/seg/mmseg/models/utils/involution_naive.py
+++ b/seg/mmseg/models/utils/involution_naive.py
@@ -7,10 +7,12 @@ class involution(nn.Module):
     def __init__(self,
                  channels,
                  kernel_size,
-                 stride):
+                 stride,
+                 dilation=1):
         super(involution, self).__init__()
         self.kernel_size = kernel_size
         self.stride = stride
+        self.dilation=dilation
         self.channels = channels
         reduction_ratio = 4
         self.group_channels = 16
@@ -32,7 +34,7 @@ class involution(nn.Module):
             act_cfg=None)
         if stride > 1:
             self.avgpool = nn.AvgPool2d(stride, stride)
-        self.unfold = nn.Unfold(kernel_size, 1, (kernel_size-1)//2, stride)
+        self.unfold = nn.Unfold(kernel_size, dilation, dilation * (kernel_size-1) // 2, stride)
 
     def forward(self, x):
         weight = self.conv2(self.conv1(x if self.stride == 1 else self.avgpool(x)))


### PR DESCRIPTION
I added some args for dilation. Therefore, the generated kernel could compute with dilated pixels. It might be helpful to expand receptive field in RedNet backbone without losing feature map size in some tasks like detection and segmentation.
For example, `dilations=(1, 1, 2, 4), strides=(1, 2, 1, 1)` instead of 'strides=(1, 2, 2, 2)' in configs.
